### PR TITLE
Allows NLopt to be in a non-standard directory.

### DIFF
--- a/cmake/FindNLopt.cmake
+++ b/cmake/FindNLopt.cmake
@@ -16,6 +16,10 @@
 #   NLopt_LIBRARIES - list of libraries to be linked
 #
 
+# Modified by Adam Boutcher, IPPP - Durham University
+# Supports NLopt in a non-standard directory unknown to the ld linker.
+string(REPLACE ":" ";" NLopt_INCLUDE_DIR $ENV{NLopt_INCLUDE_DIR})
+
 find_package(PkgConfig)
 pkg_check_modules(PC_NLopt QUIET NLopt)
 
@@ -23,10 +27,19 @@ find_path(NLopt_INCLUDE_DIR
   NAMES nlopt.hpp
   PATHS ${PC_NLopt_INCLUDE_DIRS}
 )
+find_path(NLopt_INCLUDE_DIR
+  NAMES nlopt.hpp
+  PATHS ${NLopt_INCLUDE_DIR}
+)
+
 
 find_library(NLopt_LIBRARY
   NAMES nlopt nlopt_cxx
   PATHS ${PC_NLopt_LIBRARY_DIRS}
+)
+find_library(NLopt_LIBRARY
+  NAMES nlopt nlopt_cxx
+  PATHS ${NLopt_INCLUDE_DIR}
 )
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
This modification allows Nlopt to be in a non-standard location and specified using the environment variable "NLopt_INCLUDE_DIR".

find_package doesn't use LD_LIBRARY_PATH, this change still doesn't to ensure expected behaviour but it does look for the above variable. this can be colon separated if you split the libraries and headers (e.g. install it properly but with a different prefix), this will also support a lazy "make" of NLopt without the requirement to install.