### PR TITLE
System Environment options for BubbleProfile CMAKE files.

### DIFF
--- a/BubbleProfiler/cmake/FindGiNaC.cmake
+++ b/BubbleProfiler/cmake/FindGiNaC.cmake
@@ -16,6 +16,9 @@
 #   GINAC_LIBRARIES - list of libraries to be linked
 #
 
+string(REPLACE ":" ";" GINAC_INCLUDE_DIR $ENV{GINAC_INCLUDE_DIR})
+
+
 find_package(CLN 1.2.2 REQUIRED)
 
 find_package(PkgConfig)
@@ -29,6 +32,16 @@ find_path(GINAC_INCLUDE_DIR
 find_library(GINAC_LIBRARY
   NAMES libginac ginac
   PATHS ${PC_GINAC_LIBRARY_DIRS}
+)
+
+find_path(GINAC_INCLUDE_DIR
+  NAMES ginac/ginac.h
+  PATHS ${GINAC_INCLUDE_DIR}
+)
+
+find_library(GINAC_LIBRARY
+  NAMES libginac ginac
+  PATHS ${GINAC_INCLUDE_DIR}
 )
 
 include(FindPackageHandleStandardArgs)

--- a/BubbleProfiler/cmake/FindNLopt.cmake
+++ b/BubbleProfiler/cmake/FindNLopt.cmake
@@ -16,6 +16,10 @@
 #   NLopt_LIBRARIES - list of libraries to be linked
 #
 
+# Modified by Adam Boutcher, IPPP - Durham University
+# Supports NLopt in a non-standard directory unknown to the ld linker.
+string(REPLACE ":" ";" NLopt_INCLUDE_DIR $ENV{NLopt_INCLUDE_DIR})
+
 find_package(PkgConfig)
 pkg_check_modules(PC_NLopt QUIET NLopt)
 
@@ -23,10 +27,19 @@ find_path(NLopt_INCLUDE_DIR
   NAMES nlopt.hpp
   PATHS ${PC_NLopt_INCLUDE_DIRS}
 )
+find_path(NLopt_INCLUDE_DIR
+  NAMES nlopt.hpp
+  PATHS ${NLopt_INCLUDE_DIR}
+)
+
 
 find_library(NLopt_LIBRARY
   NAMES nlopt nlopt_cxx
   PATHS ${PC_NLopt_LIBRARY_DIRS}
+)
+find_library(NLopt_LIBRARY
+  NAMES nlopt nlopt_cxx
+  PATHS ${NLopt_INCLUDE_DIR}
 )
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
same as before.

NLopt_INCLUDE_DIR for where NLopt is, accepts colon separated values.
GINAC_INCLUDE_DIR for where GiNaC is, accepts colon separated values.

Probably not very clean code.